### PR TITLE
FIx for Error 500 on Ajax Request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": "7.4.9",
+        "php": "7.4.19",
         "laravel/framework": "5.2.*",
         "laravelcollective/html": "^5.2",
         "intervention/image": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4040,7 +4040,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "7.4.9"
+        "php": "7.4.19"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -5,8 +5,12 @@
 $.ajaxSetup({
 
     type: "POST",
+	headers: {
+		'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+	},
 
 });
+
 function addNode(parent,type,id,name,classTxt,value,inpType,textNode){
 	//var parent = document.getElementById(parentId);
 	var tmp = document.createElement(type);


### PR DESCRIPTION
When requesting on AJAX to PHP we need to include CSRF token. The reason why the Error 500 is happening on dashboards is that we are not passing CSRF token on headers. 

Reference: [AJAX CSRF Setup Laravel](https://laravel.com/docs/8.x/csrf#csrf-x-csrf-token)